### PR TITLE
Change the default PDF engine

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -1,5 +1,5 @@
 @default_files = ('Thesis.tex');
 
-$pdflatex = 'pdflatex  %O  --shell-escape %S';
-$pdf_mode = 1;
+$lualatex = 'lualatex  %O  --shell-escape %S';
+$pdf_mode = 5;
 $clean_ext = "%R.acn %R.acr %R.alg %R.aux %R.auxlock %R.bak %R.bbl %R.blg %R.dvi %R.fls %R.glg %R.glo %R.gls %R.idx %R.ist %R.ilg %R.ind %R.log %R.out %R.pdf %R.ps %R.sav %R.swp %R.toc %R.run.xml %R-blx.bib %R_latexmk %R~ %R.pgf-plot.%R Figures/External/"


### PR DESCRIPTION
Since in the `thesis.tex`  
```
\ifxetexorluatex
  \setmainfont{Minion Pro}.
```
is used.
I believe the `latexmkrc` file should avoid using `pdflatex`