### PR TITLE
Make glossaries works

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -1,5 +1,12 @@
 @default_files = ('Thesis.tex');
 
+ add_cus_dep( 'acn', 'acr', 0, 'makeglossaries' );
+ add_cus_dep( 'glo', 'gls', 0, 'makeglossaries' );
+ sub makeglossaries {
+    my ($name, $path) = fileparse( $$Psource );
+    return system "makeglossaries -d '$path' '$name'";
+}
+
 $lualatex = 'lualatex  %O  --shell-escape %S';
-$pdf_mode = 5;
+$pdf_mode = 4;
 $clean_ext = "%R.acn %R.acr %R.alg %R.aux %R.auxlock %R.bak %R.bbl %R.blg %R.dvi %R.fls %R.glg %R.glo %R.gls %R.idx %R.ist %R.ilg %R.ind %R.log %R.out %R.pdf %R.ps %R.sav %R.swp %R.toc %R.run.xml %R-blx.bib %R_latexmk %R~ %R.pgf-plot.%R Figures/External/"


### PR DESCRIPTION
When I try to compiler, the glossaries entry doesn't show up, so I did some Google works.
Previous log
```
=== TeX engine is 'LuaTeX'
Latexmk: Index file 'Thesis.idx' was written
Latexmk: Found input bbl file 'Thesis.bbl'
Latexmk: Missing input file: 'Thesis.acr' from line
  'No file Thesis.acr.'
Latexmk: Missing input file: 'Thesis.gls' from line
  'No file Thesis.gls.'
Latexmk: Log file says output to 'Thesis.pdf'
Latexmk: Found biber source file(s) [Thesis.bcf Thesis.bib]
Latexmk: All targets () are up-to-date
```
And correct me if I'm wrong, but It seems `makeglossaries` has to be manually called.
The code is copied from another [repo](http://ctan.tug.org/tex-archive/support/latexmk/example_rcfiles/glossary_latexmkrc)