### PR TITLE
Unicode bookmarks

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -35,6 +35,7 @@
   citecolor  = RoyalBlue,
   linkcolor  = RoyalBlue,
   urlcolor   = RoyalBlue,
+  unicode,
   ]{hyperref}
 
 \usepackage{bookmark}


### PR DESCRIPTION
This allows unicode characters in bookmarks as metion in 11.5 form the hyperref manual. (ftp://tug.ctan.org/pub/tex-archive/macros/latex/contrib/hyperref/doc/manual.pdf)