### PR TITLE
Various improvements

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -58,6 +58,11 @@
 
 \ifxetexorluatex
   \setmainfont{Minion Pro}
+  % Most fonts don't support ordinals, but if yours does, this may give better results:
+  \renewcommand{\st}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{st}}\xspace}
+  \renewcommand{\rd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{rd}}\xspace}
+  \renewcommand{\nd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{nd}}\xspace}
+  \renewcommand{\th}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{th}}\xspace}
 \else
   \usepackage[lf]{ebgaramond}
   \usepackage[oldstyle,scale=0.7]{sourcecodepro}

--- a/mimosis.cls
+++ b/mimosis.cls
@@ -199,17 +199,10 @@
 % Ordinals
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\ifxetexorluatex
-  \newcommand  {\st}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{st}}\xspace}
-  \newcommand  {\rd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{rd}}\xspace}
-  \newcommand  {\nd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{nd}}\xspace}
-  \renewcommand{\th}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{th}}\xspace}
-\else
-  \newcommand  {\st}{\textsuperscript{\textup{st}}\xspace}
-  \newcommand  {\rd}{\textsuperscript{\textup{rd}}\xspace}
-  \newcommand  {\nd}{\textsuperscript{\textup{nd}}\xspace}
-  \renewcommand{\th}{\textsuperscript{\textup{th}}\xspace}
-\fi
+\newcommand  {\st}{\textsuperscript{\textup{st}}\xspace}
+\newcommand  {\rd}{\textsuperscript{\textup{rd}}\xspace}
+\newcommand  {\nd}{\textsuperscript{\textup{nd}}\xspace}
+\renewcommand{\th}{\textsuperscript{\textup{th}}\xspace}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Penalties

--- a/mimosis.cls
+++ b/mimosis.cls
@@ -160,11 +160,14 @@
 \RequirePackage{siunitx}
 
 \sisetup{%
-  detect-all           = true,
-  detect-family        = true,
-  detect-mode          = true,
-  detect-shape         = true,
-  detect-weight        = true,
+  mode = match,
+  propagate-math-font = true,
+  reset-math-version = false,
+  reset-text-family = false,
+  reset-text-series = false,
+  reset-text-shape = false,
+  text-family-to-math = true,
+  text-series-to-math = true,
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/mimosis.cls
+++ b/mimosis.cls
@@ -15,19 +15,13 @@
            toc=bibliography,
            toc=index,]{scrbook}
 
-\RequirePackage{ifpdf}
-\RequirePackage{ifxetex}
-\RequirePackage{ifluatex}
-
-\newif\ifxetexorluatex
+\RequirePackage{iftex}
+\newif\ifxetexorluatex\xetexorluatexfalse
 \ifxetex
   \xetexorluatextrue
-\else
-  \ifluatex
-    \xetexorluatextrue
-  \else
-    \xetexorluatexfalse
-  \fi
+\fi
+\ifluatex
+  \xetexorluatextrue
 \fi
 
 \ifxetexorluatex

--- a/mimosis.cls
+++ b/mimosis.cls
@@ -33,6 +33,7 @@
 \ifxetexorluatex
   \RequirePackage{fontspec}
 \else
+  \RequirePackage[T1]{fontenc}
   \RequirePackage[utf8]{inputenc}
 \fi
 


### PR DESCRIPTION
- In a previous commit, I overlooked the fact that all other options for siunitx were also deprecated in recent versions of the package. Note: I have tested this with the most recent version of TeX Live on my local machine. I have **not** tested it with TeX Live 2020, which is the latest version on Overleaf. If Overleaf is your main target platform, you'll need to check that these changes are compatible. (NB: it may be a good idea to remove any non-essential and somewhat unstable packages from the document class and leave it for the user to decide whether and how to invoke them. So perhaps you'll want to move this part from mimosis.cls to Thesis.tex.).
- I moved the ordinals based on a rare font feature from mimosis.cls to Thesis.tex. Most fonts don't support this, so the document class should not assume that the feature is present.