### PR TITLE
fix: Moved font ordinals to Thesis.tex.

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -58,6 +58,11 @@
 
 \ifxetexorluatex
   \setmainfont{Minion Pro}
+  % Most fonts don't support ordinals, but if yours does, this may give better results:
+  \renewcommand{\st}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{st}}\xspace}
+  \renewcommand{\rd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{rd}}\xspace}
+  \renewcommand{\nd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{nd}}\xspace}
+  \renewcommand{\th}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{th}}\xspace}
 \else
   \usepackage[lf]{ebgaramond}
   \usepackage[oldstyle,scale=0.7]{sourcecodepro}

--- a/mimosis.cls
+++ b/mimosis.cls
@@ -201,17 +201,10 @@
 % Ordinals
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\ifxetexorluatex
-  \newcommand  {\st}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{st}}\xspace}
-  \newcommand  {\rd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{rd}}\xspace}
-  \newcommand  {\nd}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{nd}}\xspace}
-  \renewcommand{\th}{{\addfontfeatures{VerticalPosition=Ordinal}\textup{th}}\xspace}
-\else
-  \newcommand  {\st}{\textsuperscript{\textup{st}}\xspace}
-  \newcommand  {\rd}{\textsuperscript{\textup{rd}}\xspace}
-  \newcommand  {\nd}{\textsuperscript{\textup{nd}}\xspace}
-  \renewcommand{\th}{\textsuperscript{\textup{th}}\xspace}
-\fi
+\newcommand  {\st}{\textsuperscript{\textup{st}}\xspace}
+\newcommand  {\rd}{\textsuperscript{\textup{rd}}\xspace}
+\newcommand  {\nd}{\textsuperscript{\textup{nd}}\xspace}
+\renewcommand{\th}{\textsuperscript{\textup{th}}\xspace}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Penalties


### PR DESCRIPTION
Since most fonts do not support this feature, it should be chosen by the
user and not be enforced by the class.  See also #14.

I should add: If using a font that does not support this feature (such as Baskerville, which is mentioned in Thesis.tex), then latex throws a warning message about a missing font feature. `mimosis.cls` should avoid this warning message, either by suppressing the warning message somehow or by not enforcing the feature. The proposed commit chooses the latter option.