### PR TITLE
feat: Improved font loading in Thesis.tex.

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -56,15 +56,12 @@
 % Fonts
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\ifxetexorluatex
-  \usepackage{unicode-math}
-  \setmainfont{EB Garamond}
-  \setmathfont{Garamond Math}
-  \setmonofont[Scale=MatchLowercase]{Source Code Pro}
+\usepackage[cmintegrals,cmbraces]{newtxmath}
+\usepackage{ebgaramond-maths}
+\ifpdftex
+  \usepackage[scale=0.8]{sourcecodepro}
 \else
-  \usepackage[lf]{ebgaramond}
-  \usepackage[oldstyle,scale=0.7]{sourcecodepro}
-  \singlespacing
+  \usepackage[scale=MatchLowercase]{sourcecodepro}
 \fi
 
 \newacronym[description={Principal component analysis}]{PCA}{PCA}{principal component analysis}


### PR DESCRIPTION
I found that the explicit \setmainfont etc. commands may have loaded a
system-provided font instead of the TeX-Live provided font, which caused
various interoperability issues. Loading the packages is more
appropriate as they will load the correct font variants for whatever
variant of latex is being used.

Preloading newtxmath is recommended as per:
http://mirrors.ctan.org/fonts/ebgaramond-maths/ebgaramond-maths.pdf