### PR TITLE
Clickable author names

### DIFF
--- a/bibliography-mimosis.tex
+++ b/bibliography-mimosis.tex
@@ -130,3 +130,34 @@
 }
 
 \DeclareLanguageMapping{english}{english-mimosis}
+
+% This block produces clickable and colored author names whenever \textcite is used 
+\DeclareFieldFormat{citehyperref}{%
+  \DeclareFieldAlias{bibhyperref}{noformat}% Avoid nested links
+  \bibhyperref{#1}}
+\DeclareFieldFormat{textcitehyperref}{%
+  \DeclareFieldAlias{bibhyperref}{noformat}% Avoid nested links
+  \bibhyperref{%
+    #1%
+    \ifbool{cbx:parens}
+      {\bibcloseparen\global\boolfalse{cbx:parens}}
+      {}}}
+\savebibmacro{cite}
+\savebibmacro{textcite}
+\renewbibmacro*{cite}{%
+  \printtext[citehyperref]{%
+    \restorebibmacro{cite}%
+    \usebibmacro{cite}}}
+\renewbibmacro*{textcite}{%
+  \ifboolexpr{
+    ( not test {\iffieldundef{prenote}} and
+      test {\ifnumequal{\value{citecount}}{1}} )
+    or
+    ( not test {\iffieldundef{postnote}} and
+      test {\ifnumequal{\value{citecount}}{\value{citetotal}}} )
+  }
+    {\DeclareFieldAlias{textcitehyperref}{noformat}}
+    {}%
+  \printtext[textcitehyperref]{%
+    \restorebibmacro{textcite}%
+    \usebibmacro{textcite}}} 


### PR DESCRIPTION
Currently, upon using `\textcite` the reference formatting does not extend to the author names.

In other words, the numbers are colored in text and are clickable (bringing you to the bibliography) but the author names appear in plain text.

This PR extends the formatting of the number `[1]` to the author names.