### PR TITLE
add symbols missing from garamond math

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -59,7 +59,9 @@
 \ifxetexorluatex
   \usepackage{unicode-math}
   \setmainfont{EB Garamond}
-  \setmathfont{Garamond Math}
+  \setmathfont{Garamond Math}%[StylisticSet={6,7,8,9,10}] 
+  %load missing symbols from other font
+  \setmathfont{STIX Two Math}[range={\sharp, \natural, \flat, \clubsuit, \spadesuit, \checkmark}]
   \setmonofont[Scale=MatchLowercase]{Source Code Pro}
 \else
   \usepackage[lf]{ebgaramond}


### PR DESCRIPTION
The Garamond Math font misses some symbols, which are now loaded from STIX Two Math. 
Also added a comment to point towards the StylisticSet options.