### PR TITLE
decrease font size in citations relatively

### DIFF
--- a/bibliography-mimosis.tex
+++ b/bibliography-mimosis.tex
@@ -124,9 +124,10 @@
 
 % Make the font size of citations smaller. Depending on your selected
 % font, you might not need this.
+\usepackage{relsize}
 \renewcommand*{\citesetup}{%
   \biburlsetup
-  \small
+  \relsize{-.5}%
 }
 
 \DeclareLanguageMapping{english}{english-mimosis}


### PR DESCRIPTION
In the current version, the font size in citations is hard coded to \small. This can become problematic, when citing inside an environment with different  font size than \normalsize, e.g., tables, footnotes, section titles, etc.

I suggest adjusting the font size using the relsize package, which changes the size relatively to the surrounding text size. \relsize{-.5}  reduces font size by  factor of 1.2^(-0.5), e.g., \normalsize (10.95pt) to \small (10pt) 